### PR TITLE
Switch presence to uptime

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -4,7 +4,7 @@ require('dotenv').config();
 const { token } = process.env;
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const fs = require('fs');
-const { initTrialPresence } = require('./utils/presence');
+const { initUptimePresence } = require('./utils/presence');
 
 
 
@@ -33,8 +33,7 @@ const { init } = require('./utils/db');
 client.once('ready', async () => {
   await init();
   console.log(`Logged in as ${client.user.tag}`);
-  // initUptimePresence(client);
-  initTrialPresence(client);
+  initUptimePresence(client);
   console.log('✅ Database initialized, balances table is ready.');
   // ... any other ready logic
 });

--- a/src/utils/presence.js
+++ b/src/utils/presence.js
@@ -16,37 +16,8 @@ function formatDuration(ms) {
 }
 
 /**
- * Initialize presence to show remaining trial time.
- * Requires an env var TRIAL_END_DATE (ISO string), e.g. 2025-06-23T00:00:00Z
+ * Initialize presence to show the bot's current runtime.
  */
-function initTrialPresence(client) {
-  const updateInterval = 60_000; // every minute
-  setInterval(() => {
-    const endDate = process.env.TRIAL_END_DATE
-      ? new Date(process.env.TRIAL_END_DATE)
-      : null;
-    let statusText;
-    if (endDate) {
-      const remainingMs = endDate - Date.now();
-      statusText = remainingMs > 0
-        ? `DOOMSDAY in: ${formatDuration(remainingMs)}`
-        : 'DOOMSDAY';
-    } else {
-      statusText = 'DOOMSDAY date not set';
-    }
-
-    client.user.setPresence({
-      activities: [{
-        name: statusText,
-        type: ActivityType.Watching
-      }],
-      status: 'online'
-    });
-  }, updateInterval);
-}
-
-// Backup uptime presence (commented out)
-/*
 function initUptimePresence(client) {
   const updateInterval = 60_000; // every minute
   setInterval(() => {
@@ -60,9 +31,7 @@ function initUptimePresence(client) {
     });
   }, updateInterval);
 }
-*/
 
 module.exports = {
-  initTrialPresence,
-  // initUptimePresence,
+  initUptimePresence,
 };


### PR DESCRIPTION
## Summary
- replace DOOMSDAY presence with uptime presence
- use the new presence initializer when the bot is ready

## Testing
- `npm test` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685c601289548325b2f830978c04eb0f